### PR TITLE
Change versioning to include patch number and build metadata

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -168,12 +168,34 @@ tasks {
 fun readResource(name: String) = file("resources/$name").readText()
 
 /**
- * Function which creates a plugin version.
+ * Function which creates a plugin version in SemVer format
+ *
+ * Examples:
+ *
+ * GIVEN (GitHub workflow environment):
+ *  GITHUB_RUN_NUMBER: 30
+ *  major: 2
+ *  minor: 1
+ *  patch: 1
+ *  sdkVersion: IC-2022.2
+ *
+ * RETURNS:
+ *  2.1.1+30-IC-2022.2
+ *
+ *
+ * GIVEN (local dev environment):
+ *  GITHUB_RUN_NUMBER: null
+ *  major: 2
+ *  minor: 2
+ *  patch: 34
+ *  sdkVersion: IC-2022.3
+ *
+ * RETURNS:
+ *  2.2.34+0-IC-2022.3+alpha
  */
 fun pluginVersion(major: String, minor: String, patch: String) =
     listOf(
         major,
         minor,
-        patch,
-        maybeGithubRunNumber?.let { "$it-${descriptor.sdkVersion}" } ?: "0-${descriptor.sdkVersion}+alpha"
+        maybeGithubRunNumber?.let { "$patch+$it-${descriptor.sdkVersion}" } ?: "$patch+0-${descriptor.sdkVersion}+alpha"
     ).joinToString(".")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -77,7 +77,7 @@ val pluginGroup: String by project
 // `pluginName_` variable ends with `_` because of the collision with Kotlin magic getter in the `intellij` closure.
 // Read more about the issue: https://github.com/JetBrains/intellij-platform-plugin-template/issues/29
 val pluginName_: String by project
-val pluginVersion: String = pluginVersion(major = "2", minor = "1", patch = "1")
+val pluginVersion: String = pluginVersion(major = "2", minor = "2", patch = "0")
 val pluginDescriptionFile: String by project
 val pluginChangeNotesFile: String by project
 


### PR DESCRIPTION
### Revision 2
- Updates version strategy to use GITHUB_BUILD_NUMBER as metadata to patch field
- Bumps minor version

### Revision 1

> This reverts commit 6f85fd1c371b63bb4887a54990b9f6574213a197.
> 
> *Issue #, if available:*
> 
> *Description of changes:*
> - This commit added a patch to the version number of the plugin, however patch is already added by referencing the `GITHUB_RUN_NUMBER` environment variable. Reverting this will restore the semantic version and allow us to publish to repository. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
