### PR TITLE
Support formatting for Idea 2023

### DIFF
--- a/src/IC-231/kotlin/com/amazon/ion/plugin/intellij/formatting/IonFormattingModelBuilder.kt
+++ b/src/IC-231/kotlin/com/amazon/ion/plugin/intellij/formatting/IonFormattingModelBuilder.kt
@@ -1,0 +1,34 @@
+package com.amazon.ion.plugin.intellij.formatting
+
+import com.amazon.ion.plugin.intellij.formatting.blocks.IonBlockOptions
+import com.amazon.ion.plugin.intellij.formatting.blocks.RootIonBlock
+import com.intellij.formatting.FormattingContext
+import com.intellij.formatting.FormattingModel
+import com.intellij.formatting.FormattingModelBuilder
+import com.intellij.formatting.FormattingModelProvider
+
+/**
+ * Creates the block model for an Ion file.
+ *
+ * The block model will determine how elements are spaced, indented and aligned.
+ */
+class IonFormattingModelBuilder : FormattingModelBuilder {
+    override fun createModel(formattingContext: FormattingContext): FormattingModel {
+        val element = formattingContext.psiElement
+        val settings = formattingContext.codeStyleSettings
+
+        val rootBlock = RootIonBlock(
+            node = element.node,
+            options = IonBlockOptions(
+                spaceBuilder = IonCodeBlockSpacingProvider(settings),
+                codeStyle = settings
+            )
+        )
+
+
+        return FormattingModelProvider.createFormattingModelForPsiFile(
+            element.containingFile,
+            rootBlock, settings
+        )
+    }
+}


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/amazon-ion/ion-intellij-plugin/issues/48

*Description of changes:*
Added `IonFormattingModelBuilder` for IC-231 the same as it was for IC-222 which solves the issue for Idea 2023 when `Reformat Code` in Ion file is executed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
