### PR TITLE
Support IntelliJ 2023.1.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        product: [ "IC-2022.2", "231.4840-EAP-CANDIDATE-SNAPSHOT" ]
+        product: [ "IC-2022.2", "IC-2023.1"]
       max-parallel: 5
     env:
       PRODUCT_NAME: ${{ matrix.product }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        product: [ "IC-2022.2", "231.4840-EAP-CANDIDATE-SNAPSHOT" ]
+        product: [ "IC-2022.2", "IC-2023.1"]
       max-parallel: 5
     env:
       PRODUCT_NAME: ${{ matrix.product }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
   release:
     strategy:
       matrix:
-        product: [ "IC-2022.2" ]
+        product: [ "IC-2022.2", "IC-2023.1" ]
       max-parallel: 1
     env:
       PRODUCT_NAME: ${{ matrix.product }}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,7 +34,7 @@ val plugins = listOf(
     PluginDescriptor(
         since = "231",
         until = "231.*",
-        sdkVersion = "231.4840-EAP-CANDIDATE-SNAPSHOT",
+        sdkVersion = "IC-2023.1",
         platformType = PlatformType.IdeaCommunity,
         sourceFolder = "IC-231",
         kotlin = KotlinOptions(
@@ -44,7 +44,7 @@ val plugins = listOf(
     )
 )
 
-val defaultProductName = "231.4840-EAP-CANDIDATE-SNAPSHOT"
+val defaultProductName = "IC-2023.1"
 val productName = System.getenv("PRODUCT_NAME") ?: defaultProductName
 val maybeGithubRunNumber = System.getenv("GITHUB_RUN_NUMBER")?.toInt()
 val descriptor = plugins.first { it.sdkVersion == productName }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -11,5 +11,5 @@ repositories {
 }
 
 dependencies {
-    api(kotlin("gradle-plugin", version = "1.7.10"))
+    api(kotlin("gradle-plugin", version = "1.9.0-Beta"))
 }


### PR DESCRIPTION
*Issue #, if available:*
[Plugin 'Amazon Ion' (version '2.3.0+7-IC-2022.2') is not compatible with the current version of the IDE, because it requires build 223.* or older but the current build is IU-231.9011.34](https://github.com/amazon-ion/ion-intellij-plugin/pull/49#issuecomment-1579880529)
*Description of changes:*
This PR updates the supported IntelliJ version to fix the issue described above.  

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
