### PR TITLE
Updates 'org.jetbrains.intellij' version to fix the task failure of downloadZipSigner.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,7 +12,7 @@ buildscript {
 
 plugins {
     kotlin("jvm")
-    id("org.jetbrains.intellij") version "1.12.0"
+    id("org.jetbrains.intellij") version "1.13.2"
 }
 
 repositories {
@@ -107,18 +107,18 @@ tasks {
     compileKotlin {
         kotlinOptions {
             apiVersion = descriptor.kotlin.apiVersion
-            jvmTarget = "11"
+            jvmTarget = "17"
         }
     }
 
     withType<KotlinCompile> {
         kotlinOptions {
-            jvmTarget = "11"
+            jvmTarget = "17"
         }
     }
 
     withType<JavaCompile> {
-        options.release.set(11)
+        options.release.set(17)
     }
 
     buildPlugin {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,6 +12,8 @@ buildscript {
 
 plugins {
     kotlin("jvm")
+    // TODO: The version need to be updated to the latest version 1.15.0.
+    // There will be configuration issues need to be solved after upgrading to the latest version 1.15.0.
     id("org.jetbrains.intellij") version "1.13.2"
 }
 

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -11,5 +11,5 @@ repositories {
 }
 
 dependencies {
-    api(kotlin("gradle-plugin", version = "1.9.0-Beta"))
+    api(kotlin("gradle-plugin", version = "1.9.0"))
 }


### PR DESCRIPTION
*Issue #, if available:*
The [release workflow](https://github.com/amazon-ion/ion-intellij-plugin/actions/runs/5548635043) failed since the [task](https://github.com/amazon-ion/ion-intellij-plugin/actions/runs/5548635043/jobs/10164535399#step:6:80) `downloadZipSigner` failed. 

*Description of changes:*
This PR updates the `org.jetbrains.intellij` version from `1.12.0` to `1.13.2 ` to fix the workflow failure. According to this [issue](https://github.com/JetBrains/gradle-intellij-plugin/issues/1319), the `downloadZipSigner `failure error has been fixed since `org.jetbrains.intellij 1.13.1-SNAPSHOT`.  

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
