### PR TITLE
Release v2.4.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -66,7 +66,7 @@ val pluginGroup: String by project
 // `pluginName_` variable ends with `_` because of the collision with Kotlin magic getter in the `intellij` closure.
 // Read more about the issue: https://github.com/JetBrains/intellij-platform-plugin-template/issues/29
 val pluginName_: String by project
-val pluginVersion: String = pluginVersion(major = "2", minor = "3", patch = "2")
+val pluginVersion: String = pluginVersion(major = "2", minor = "4", patch = "0")
 val pluginDescriptionFile: String by project
 val pluginChangeNotesFile: String by project
 


### PR DESCRIPTION
*Description of changes:*
This PR works on release v24..0 which adds support for IntelliJ 2023.2.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
