### PR TITLE
Update to supported version of upload-artifact GitHub action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,7 +93,7 @@ jobs:
 
       # Publish plugin to beta channel
       - name: Publish Beta Plugin
-        if: github.repository == 'amzn/ion-intellij-plugin'
+        if: github.repository == 'amazon-ion/ion-intellij-plugin'
         env:
           PUBLISH_TOKEN: ${{ secrets.JETBRAINS_TOKEN }}
           PUBLISH_CHANNEL: beta
@@ -101,8 +101,8 @@ jobs:
 
       # Upload plugin artifact to make it available in the next jobs
       - name: Upload artifact
-        if: github.repository == 'amzn/ion-intellij-plugin'
-        uses: actions/upload-artifact@v1
+        if: github.repository == 'amazon-ion/ion-intellij-plugin'
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.product }}-plugin-artifact
           path: ./build/distributions/${{ needs.build.outputs.artifact }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -95,7 +95,7 @@ jobs:
 
       # Upload plugin artifact to make it available in the next jobs
       - name: Upload artifact
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.product }}-plugin-artifact
           path: ./build/distributions/${{ needs.build.outputs.artifact }}


### PR DESCRIPTION
**Issue #, if available:**

None

**Description of changes:**

In #70, the workflows are failing because they use an unsupported version of the `upload-artifact` action. This updates to the latest version of the `upload-artifact` action.


_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
