### PR TITLE
Fix plugin version

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -36,17 +36,16 @@ val pluginGroup: String by project
 // `pluginName_` variable ends with `_` because of the collision with Kotlin magic getter in the `intellij` closure.
 // Read more about the issue: https://github.com/JetBrains/intellij-platform-plugin-template/issues/29
 val pluginName_: String by project
-val pluginVersion: String = pluginVersion(major = "2", minor = "8", patch = "1")
+val pluginVersion: String = pluginVersion(major = "2", minor = "7", patch = "0")
 val supportedSinceIdeVersion: String by project
 val supportedUntilIdeVersion: String by project
 val pluginDescriptionFile: String by project
 val pluginChangeNotesFile: String by project
 
 val platformVersion: String by project
-val packageVersion: String by project
 
 group = pluginGroup
-version = packageVersion
+version = pluginVersion
 
 logger.lifecycle("Building Amazon Ion $pluginVersion")
 
@@ -74,7 +73,7 @@ dependencies {
 intellijPlatform {
     pluginConfiguration {
         name.set(pluginName_)
-        version.set(packageVersion)
+        version.set(pluginVersion)
         description.set(readResource(pluginDescriptionFile))
         changeNotes.set(readResource(pluginChangeNotesFile))
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,8 +13,6 @@ supportedSinceIdeVersion = 231.1
 # might not even exist by then.
 supportedUntilIdeVersion = 993.*
 
-packageVersion = 2.0
-
 # Opt-out flag for bundling Kotlin standard library.
 # See https://kotlinlang.org/docs/reference/using-gradle.html#dependency-on-the-standard-library for details.
 kotlin.stdlib.default.dependency = false


### PR DESCRIPTION
**Issue #, if available:**

Follow up for #73 

**Description of changes:**

Publishing a beta release failed because it tried to publish version `2.0`. I looked into the git history, and I don't know why the `packageVersion` gradle property even exists. It wasn't being used for anything prior as far as I can tell, and I guess in the migration to using the new intellijPlatform gradle plugin, it did end up getting used inadvertently. 

I've also lowered the plugin version because the most recent release is `2.6.1`, so there's no reason to go to `2.8.1` for the next release.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
