### PR TITLE
Verify against Ultimate editions

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,7 +52,7 @@ logger.lifecycle("Building Amazon Ion $pluginVersion")
 dependencies {
     intellijPlatform {
         // This should be equivalent to the lowest version that we build against.
-        intellijIdeaCommunity(supportedSinceIdeVersion.let(::branchToProductReleaseVersion))
+        intellijIdeaUltimate(supportedSinceIdeVersion.let(::branchToProductReleaseVersion))
 
         bundledPlugins(listOf(
             "com.intellij.java",
@@ -95,7 +95,7 @@ intellijPlatform {
     pluginVerification {
         ides {
             select {
-                types.set(listOf(IntelliJPlatformType.IntellijIdeaCommunity))
+                types.set(listOf(IntelliJPlatformType.IntellijIdeaUltimate))
                 channels.set(
                     listOf(
                         ProductRelease.Channel.RELEASE,

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ pluginDescriptionFile = plugin-description.html
 pluginChangeNotesFile = plugin-changenotes.html
 
 # If JetBrains makes a breaking change, bump this to the latest RELEASE version and fix/update the plugin.
-supportedSinceIdeVersion = 231.1
+supportedSinceIdeVersion = 252.1
 # We could leave this unset so that it will automatically support newer IDE versions until JetBrains
 # marketplace determines that there's an incompatibility with a newer version. However, if we do that,
 # then the `printProductReleases` won't display a full range of products; it will only display the


### PR DESCRIPTION
*Issue #, if available:* #76

*Description of changes:*

Rather than try to work around when/where the Community edition exists, we'll declare ourselves to be compatible with builds 252+ and verify against the Ultimate editions only.

This is in response to IntelliJ's Unified Distribution.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
