### PR TITLE
Fix issues preventing plugin from building when targeting IU 2025.2

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,8 +10,10 @@ buildscript {
 }
 
 plugins {
-    kotlin("jvm") version "1.9.0"
-    id("org.jetbrains.intellij.platform") version "2.1.0"
+    // > "Using Kotlin 2.x is recommended for plugins targeting 2024.3 or later and required for 2025.1 or later."
+    // https://plugins.jetbrains.com/docs/intellij/using-kotlin.html#adding-kotlin-support
+    kotlin("jvm") version "2.2.20"
+    id("org.jetbrains.intellij.platform") version "2.9.0"
 }
 
 kotlin {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -96,6 +96,8 @@ intellijPlatform {
 
     pluginVerification {
         ides {
+            ide(IntelliJPlatformType.IntellijIdeaUltimate, "2025.2")
+            recommended()
             select {
                 types.set(listOf(IntelliJPlatformType.IntellijIdeaUltimate))
                 channels.set(

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,7 +13,11 @@ plugins {
     // > "Using Kotlin 2.x is recommended for plugins targeting 2024.3 or later and required for 2025.1 or later."
     // https://plugins.jetbrains.com/docs/intellij/using-kotlin.html#adding-kotlin-support
     kotlin("jvm") version "2.2.20"
-    id("org.jetbrains.intellij.platform") version "2.9.0"
+    // IDE selection for pluginVerification is broken in IntelliJ Platform Gradle Plugin 2.9.0
+    // select {} and recommended() don't work, only ide() seems to.
+    // See https://github.com/JetBrains/intellij-platform-gradle-plugin/issues/2025
+    // For now just stay on 2.8.0.
+    id("org.jetbrains.intellij.platform") version "2.8.0"
 }
 
 kotlin {
@@ -96,8 +100,6 @@ intellijPlatform {
 
     pluginVerification {
         ides {
-            ide(IntelliJPlatformType.IntellijIdeaUltimate, "2025.2")
-            recommended()
             select {
                 types.set(listOf(IntelliJPlatformType.IntellijIdeaUltimate))
                 channels.set(


### PR DESCRIPTION
*Issue #, if available:*

#76 

*Description of changes:*

Kotlin and IntelliJ platform plugin versions need updated to build targeting 2025.2. This fixes the issue preventing the `unified-distribution` branch from building. Additionally, the verify plugin gradle step is broken in the latest version of the IntelliJ platform gradle plugin (2.9.0), so it has to be kept on 2.8.0.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
