### PR TITLE
Adds override of getLanguage() to IonCodeStyleSettingsProvider

### DIFF
--- a/src/main/kotlin/com/amazon/ion/plugin/intellij/formatting/IonCodeStyleSettingsProvider.kt
+++ b/src/main/kotlin/com/amazon/ion/plugin/intellij/formatting/IonCodeStyleSettingsProvider.kt
@@ -13,6 +13,8 @@ private const val CODE_STYLE_SETTINGS_DISPLAY_NAME = "Ion"
 class IonCodeStyleSettingsProvider : CodeStyleSettingsProvider() {
     override fun getConfigurableDisplayName(): String = CODE_STYLE_SETTINGS_DISPLAY_NAME
 
+    override fun getLanguage() = IonLanguage.INSTANCE
+
     override fun createConfigurable(settings: CodeStyleSettings, modelSettings: CodeStyleSettings): CodeStyleConfigurable =
         CodeStyleConfigurableConfiguration(settings, modelSettings)
 }


### PR DESCRIPTION
**Issue #, if available:**

fixes #80 

**Description of changes:**

Override `getLanguage()` to fix this diagnostic warning message:
> Legacy configurable id calculation mode from localizable name will be used for configurable class com.amazon.ion.plugin.intellij.formatting.IonCodeStyleSettingsProvider. Please override getConfigurableId or getLanguage. 

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
